### PR TITLE
chore: bump GitHub Actions to latest + Node 24

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4


### PR DESCRIPTION
Mechanical bump of GitHub Actions to current latest and (where applicable) extend Node matrix to include 24.x. See commit message for details. Auto-generated across receptron/* + isamu/* source repos. CI on this PR is the verification.