### PR TITLE
fix: restore build and browser runtime after dependency drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@graphai/agent_filters": "^1.0.0",
     "@graphai/sleeper_agents": "^0.2.0",
+    "@graphai/stream_agent_filter": "^2.0.3",
     "@graphai/vanilla": "^1.0.9",
     "@receptron/graphai_vue_cytoscape": "^0.2.0",
     "@types/cytoscape": "^3.21.0",

--- a/src/components/HeaderMenu.vue
+++ b/src/components/HeaderMenu.vue
@@ -1,27 +1,12 @@
 <template>
   <div id="nav">
-    <template v-if="isSignedIn">
-      <router-link :to="localizedUrl('/')">Home</router-link> |
-      <router-link :to="localizedUrl('/about')">About</router-link>
-    </template>
-    <template v-else>
-      <router-link :to="localizedUrl('/')">Home</router-link> | <router-link :to="localizedUrl('/about')">About</router-link> |
-      <router-link :to="localizedUrl('/account')">Signin</router-link>
-    </template>
+    <router-link :to="localizedUrl('/')">Home</router-link> |
+    <router-link :to="localizedUrl('/about')">About</router-link>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from "vue";
-import { useIsSignedIn } from "@/utils/utils";
 
-export default defineComponent({
-  setup() {
-    const isSignedIn = useIsSignedIn();
-
-    return {
-      isSignedIn,
-    };
-  },
-});
+export default defineComponent({});
 </script>

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -26,15 +26,12 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive, ref } from "vue";
+import { defineComponent, ref } from "vue";
 
 import { useI18nParam } from "@/i18n/utils";
 
 import Languages from "@/components/Languages.vue";
 import MenuList from "@/components/MenuList.vue";
-interface UserData {
-  user: User | null;
-}
 
 export default defineComponent({
   name: "AppLayout",
@@ -43,8 +40,6 @@ export default defineComponent({
     MenuList,
   },
   async setup() {
-    const user = reactive<UserData>({ user: null });
-
     const menu = ref(false);
 
     useI18nParam();
@@ -53,8 +48,6 @@ export default defineComponent({
       menu.value = !menu.value;
     };
     return {
-      user,
-
       menu,
       toggleMenu,
     };

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -8,6 +8,7 @@ const messages = {
 
 const config = {
   legacy: false,
+  globalInjection: true,
   locale: "en",
   messages,
 };

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -7,6 +7,7 @@ declare module '*.vue' {
 declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {
     localizedUrl: (path: string) => string;
+    $t: (key: string, ...args: unknown[]) => string;
   }
 }
 export {}  // important! see note.

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -42,8 +42,10 @@ import { defineComponent, ref, computed } from "vue";
 import { GraphAI, AgentFunctionContext } from "graphai";
 
 import * as agents from "@graphai/vanilla";
-// import { sleeperAgent } from "@graphai/sleeper_agents";
-import { streamAgentFilterGenerator, httpAgentFilter } from "@graphai/agent_filters";
+// Import directly from the leaf packages: the @graphai/agent_filters barrel pulls in the
+// CLI-only console step runner (@inquirer/input → node:async_hooks), which crashes in the browser.
+import { streamAgentFilterGenerator } from "@graphai/stream_agent_filter";
+import { httpAgentFilter } from "@graphai/agent_filters/lib/filters/http_client";
 
 import { graphDataSet } from "@/utils/graph_data";
 
@@ -52,7 +54,7 @@ import { useCytoscape } from "@receptron/graphai_vue_cytoscape";
 const serverAgentIds = ["groqAgent", "slashGPTAgent", "openAIAgent", "fetchAgent", "wikipediaAgent"];
 const streamAgents = ["groqAgent", "slashGPTAgent", "openAIAgent", "streamMockAgent"];
 
-const useAgentFilter = (callback: (context: AgentFunctionContext, data: T) => void) => {
+const useAgentFilter = (callback: (context: AgentFunctionContext, data: string) => void) => {
   const streamAgentFilter = streamAgentFilterGenerator(callback);
 
   const agentFilters = [

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -14,7 +14,7 @@ export default defineComponent({
   name: "HomePage",
   components: {},
   setup() {
-    const list = ref([]);
+    const list = ref<[string, unknown][]>([]);
     const getdata = async () => {
       const url = "http://localhost:8085/agents/list";
       const result = await fetch(url, {
@@ -23,11 +23,10 @@ export default defineComponent({
         },
         method: "GET",
       });
-      const data = await result.json();
-      list.value = Object.keys(data).map((key) => {
+      const data: Record<string, unknown> = await result.json();
+      list.value = Object.keys(data).map((key): [string, unknown] => {
         return [key, data[key]];
       });
-      // console.log(data);
     };
     getdata();
 

--- a/src/views/Random.vue
+++ b/src/views/Random.vue
@@ -41,8 +41,10 @@ import { defineComponent, ref } from "vue";
 import { GraphAI, AgentFunctionContext } from "graphai";
 
 import * as agents from "@graphai/vanilla";
-import { sleeperAgent } from "@graphai/sleeper_agents";
-import { streamAgentFilterGenerator, httpAgentFilter } from "@graphai/agent_filters";
+// Import directly from the leaf packages: the @graphai/agent_filters barrel pulls in the
+// CLI-only console step runner (@inquirer/input → node:async_hooks), which crashes in the browser.
+import { streamAgentFilterGenerator } from "@graphai/stream_agent_filter";
+import { httpAgentFilter } from "@graphai/agent_filters/lib/filters/http_client";
 import { useCytoscape } from "@receptron/graphai_vue_cytoscape";
 
 import { generateGraph } from "@/utils/graph";
@@ -50,7 +52,7 @@ import { generateGraph } from "@/utils/graph";
 const serverAgentIds = ["groqAgent", "slashGPTAgent", "openAIAgent", "fetchAgent", "wikipediaAgent"];
 const streamAgents = ["groqAgent", "slashGPTAgent", "openAIAgent", "streamMockAgent"];
 
-const useAgentFilter = (callback: (context: AgentFunctionContext, data: T) => void) => {
+const useAgentFilter = (callback: (context: AgentFunctionContext, data: string) => void) => {
   const streamAgentFilter = streamAgentFilterGenerator(callback);
 
   const agentFilters = [
@@ -100,11 +102,8 @@ export default defineComponent({
     const runGraph = async () => {
       result.value = {};
       streamingData.value = {};
-      const graphai = new GraphAI(selectedGraph.value, { ...agents, sleeperAgent }, { agentFilters, bypassAgentIds: serverAgentIds });
-      graphai.onLogCallback = (log) => {
-        const isServer = serverAgentIds.includes(log.agentId);
-        updateCytoscape(log.nodeId, log.state === "executing" && isServer ? "executing-server" : log.state);
-      };
+      const graphai = new GraphAI(selectedGraph.value, { ...agents }, { agentFilters, bypassAgentIds: serverAgentIds });
+      graphai.registerCallback(updateCytoscape);
       result.value = await graphai.run();
     };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,6 +307,11 @@
   resolved "https://registry.yarnpkg.com/@graphai/stream_agent_filter/-/stream_agent_filter-2.0.1.tgz#8f268bc0f9330b433ac18867a92c09612cb82a87"
   integrity sha512-BeT7OW58inq7jM8tXk7Brhc772G2/6+7M8Sckta01WBIFDx6mQeyLXcth4gYUensGnrhvDTcE4FjI88r3SGBMQ==
 
+"@graphai/stream_agent_filter@^2.0.3":
+  version "2.0.3"
+  resolved "https://npm.flatt.tech/@graphai/stream_agent_filter/-/stream_agent_filter-2.0.3.tgz#52500e5d008c307841add780ac4e5fc1e8185ee5"
+  integrity sha512-E13navF+UUNj03zyQCqACZxBnGjmPkSKSzlLZznfrS9bh/OfDBcKiki6l+858HYpMz/5d0xPGY9GpRMymDChDw==
+
 "@graphai/vanilla@^1.0.9":
   version "1.0.19"
   resolved "https://registry.yarnpkg.com/@graphai/vanilla/-/vanilla-1.0.19.tgz#08ada2a1f326ecc73dc83965abd81ae2c0008588"


### PR DESCRIPTION
## Summary

`yarn build` (vue-tsc) currently fails on `main` with 13 TypeScript errors, and the app crashes at load in the browser (`AsyncLocalStorage is not a constructor`). Both are fallout from dependency drift. This PR restores the build and the browser runtime. It is **build/runtime only** — the ESLint flat-config migration is already on `main` (#20) and is intentionally not touched here.

- `yarn build`, `yarn lint`, `yarn format` all pass
- `/` and `/random` verified in a real browser (Playwright): no console / page errors

## Items to Confirm / Review

- **`$t` typing (`src/shims-vue.d.ts`)**: vue-i18n augments `vue`, but this project's component instance resolves `ComponentCustomProperties` from `@vue/runtime-core` (that's where the existing `localizedUrl` works), so `$t` is declared there with a pragmatic `(key: string, ...args: unknown[]) => string` signature. vue-i18n's strict per-key completion is not in effect. Also enabled `globalInjection: true` (required for `$t` in templates in Composition API mode).
- **Deep import `@graphai/agent_filters/lib/filters/http_client`**: `httpAgentFilter` only exists inside the barrel (no public subpath), so it is imported via the internal `lib/` path to avoid pulling the CLI-only console step runner (`@inquirer/input` → `node:async_hooks`) into the browser bundle. Slightly fragile across upstream versions — arguably better fixed upstream with a browser-safe `exports` map / separate package.
- **`Random.vue` behavior change**: the cytoscape `updateCytoscape` API is now single-arg (`TransactionLog`), so the old per-call `"executing-server"` coloring was dropped in favor of `registerCallback(updateCytoscape)` (same pattern as `Home.vue`).
- **Removed dead auth scaffolding**: `User`/`UserData` in `Layout.vue` and the `useIsSignedIn` branch in the unused `HeaderMenu.vue` (referenced a removed util export).

## User Prompt

- Migrate ESLint to flat config and make `build`/`lint` pass; update dependencies to the latest aligned with the lockfile, and fix the build.
- After running the dev server, the browser threw `AsyncLocalStorage is not a constructor`; fix it before opening a PR.
- Confirm whether the CSS styling changed (it did not — no style source was touched; keep Tailwind at the latest).
- The earlier PR was based on a stale `main` (ESLint flat config had since been merged via #20); close it and re-open a fresh PR off current `main` containing only the still-needed build and browser-runtime fixes.

## Changes

### Build (TypeScript) fixes
- Replace the undefined `data: T` annotation with `string` in the agent-filter callbacks (`Home.vue`, `Random.vue`).
- Drop the removed `sleeperAgent` export (the generated graph only uses `streamMockAgent`).
- Switch `Random.vue` to single-arg `registerCallback(updateCytoscape)` for the current cytoscape API.
- Type `List.vue`'s ref as `[string, unknown][]` (was inferred `never[]`).
- Remove dead `User`/auth leftovers (`Layout.vue`, `HeaderMenu.vue`).
- Add `$t` to `ComponentCustomProperties` + enable i18n `globalInjection`.

### Browser runtime fix
- Import browser-safe filters from their leaf modules instead of the `@graphai/agent_filters` barrel, removing `@inquirer` + transitive CLI deps from the bundle. Adds `@graphai/stream_agent_filter` as a direct dependency.

## Verification

- `yarn build` — `vue-tsc` + `vite build` succeed; no `node:async_hooks` externalization warnings.
- `yarn lint` — clean (using main's `eslint.config.js`).
- `yarn format` — clean.
- Playwright (headless) on `/` and `/random`: no `pageerror`, no `console.error`. (`/list` shows `Failed to fetch` only because the `localhost:8085` backend isn't running — unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
